### PR TITLE
pth_auth now extracted from pthapi, no longer needed in config

### DIFF
--- a/albums.py
+++ b/albums.py
@@ -2,7 +2,6 @@ from HTMLParser import HTMLParser
 import mechanize
 import image
 from classes import Album
-from config import pth_auth
 from cStringIO import StringIO
 
 parser = HTMLParser()

--- a/apotheosis
+++ b/apotheosis
@@ -19,6 +19,7 @@ def main():
                                   api_secret=config.api_secret)
     # pth connection
     pth = pthapi.PthAPI(config.pth_username, config.pth_password)
+    print "authkey= ", pth.authkey, "\n"
 
     if len(sys.argv) > 2 and sys.argv[1] == '-C':
         collage_id = sys.argv[2]

--- a/bio.py
+++ b/bio.py
@@ -1,5 +1,5 @@
 from re import sub
-from config import pth_auth, artist_page
+from config import artist_page
 
 def missing(artist):
     return artist.bio == ''
@@ -31,7 +31,7 @@ def to_bbcode(bio):
 
 def edit(artist, pth):
     data = {'action' : 'edit',
-            'auth' : pth_auth,
+            'auth' : pth.authkey,
             'artistid' : artist.id,
             'body' : artist.bio,
             'image' : artist.image,

--- a/config.py.template
+++ b/config.py.template
@@ -3,10 +3,6 @@
 #[pth]
 pth_username =
 pth_password =
-# you can find this inspecting the html of an edit form on the site
-# try a search for 'auth' near the form tags
-# are these unique for each user? Do they change?
-pth_auth =
 # no need to change artist_page
 artist_page = 'https://passtheheadphones.me/artist.php'
 torrents_page = 'https://passtheheadphones.me/torrents.php'

--- a/image.py
+++ b/image.py
@@ -12,7 +12,7 @@ def missing(image):
 
 def bad_host(image):
     # are there any other white-listed hosts?:
-    return image.find('ptpimg.me') == -1 and image.find('imgur.com') == -1
+    return image.find('ptpimg.me') == -1 and image.find('imgur.com') == -1 and image.find('lut.im') == -1 and image.find('sli.mg') == -1
 
 
 def broken_link(image):

--- a/image.py
+++ b/image.py
@@ -3,7 +3,7 @@ import mechanize
 from contextlib2 import suppress
 from cStringIO import StringIO
 from classes import Artist, Album
-from config import artist_page, torrents_page, pth_auth, ptpimg_api_key
+from config import artist_page, torrents_page, ptpimg_api_key
 
 
 def missing(image):
@@ -60,7 +60,7 @@ def get(target, lastfm):
 
 def edit(target, pth):
     url = target.edit_url
-    r = pth.session.get(url, data={'auth': pth_auth})
+    r = pth.session.get(url, data={'auth': pth.authkey})
     forms = mechanize.ParseFile(StringIO(r.text.encode('utf-8')), url)
 
     form = get_image_field(forms)
@@ -123,7 +123,7 @@ def fix(target, pth, lastfm):
                 new_image = True
         else:
             new_image = False
-        if pth_auth is not None:
+        if pth.authkey is not None:
             if needs_rehost(target.image):
                 if not new_image:
                     print target.image

--- a/similar.py
+++ b/similar.py
@@ -1,4 +1,4 @@
-from config import max_to_add, min_score, artist_page, pth_auth
+from config import max_to_add, min_score, artist_page
 
 def find(artist, lastfm):
     # get list of current similar artists on PTH
@@ -18,7 +18,7 @@ def find(artist, lastfm):
 def add(artist, new_similar, pth):
 
     data = {'action' : 'add_similar',
-            'auth' : pth_auth,
+            'auth' : pth.authkey,
             'artistid' : artist.id,
             'artistname': ''}
 


### PR DESCRIPTION
in the pth API, self.authkey is exactly the auth key that was defined as pth_auth in the config file. I removed any reference of pth_auth from the scripts and modified them to get pth.authkey instead.
in the main script (apotheosis) i print out the auth key just to be sure, it could be removed

sorry for my bad english