### PR TITLE
Fixed blocked user-agent and removed sli.mg from whitelist.

### DIFF
--- a/image.py
+++ b/image.py
@@ -12,7 +12,7 @@ def missing(image):
 
 def bad_host(image):
     # are there any other white-listed hosts?:
-    return image.find('ptpimg.me') == -1 and image.find('imgur.com') == -1 and image.find('lut.im') == -1 and image.find('sli.mg') == -1
+    return image.find('ptpimg.me') == -1 and image.find('imgur.com') == -1 and image.find('lut.im') == -1
 
 
 def broken_link(image):

--- a/pthapi.py
+++ b/pthapi.py
@@ -11,9 +11,7 @@ from cStringIO import StringIO
 headers = {
     'Connection': 'keep-alive',
     'Cache-Control': 'max-age=0',
-    'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3)'\
-        'AppleWebKit/535.11 (KHTML, like Gecko) Chrome/17.0.963.79'\
-        'Safari/535.11',
+    'User-Agent': 'Apotheosis',
     'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9'\
         ',*/*;q=0.8',
     'Accept-Encoding': 'gzip,deflate,sdch',


### PR DESCRIPTION
The spoofed OSX user-agent in the ported pthapi.py file from pthBetter blocked the application from making API calls. The new user-agent "Apotheosis" should be valid and okay to use.

Also removed sli.mg from the whitelist as the site is basically dead at this point.